### PR TITLE
refactor: extract p6_hf_* helpers to p6huggingface module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,7 @@
 p6df::modules::huggingface::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-jupyter
+    p6m7g8-dotfiles/p6huggingface
   )
 }
 
@@ -38,6 +39,8 @@ p6df::modules::huggingface::external::brews() {
   # m1/arm
   p6df::core::homebrew::cli::brew::install cmake
   p6df::core::homebrew::cli::brew::install pkg-config
+
+  p6_return_void
 }
 
 ######################################################################
@@ -116,70 +119,6 @@ p6df::modules::huggingface::prompt::mod() {
   p6_return_str "$str"
 }
 
-
-######################################################################
-#<
-#
-# Function: p6_hf_hub_download(repo_id, filename, revision, cache_dir)
-#
-#  Args:
-#	repo_id -
-#	filename -
-#	revision -
-#	cache_dir -
-#
-#>
-######################################################################
-p6_hf_hub_download() {
-  local repo_id="$1"
-  local filename="$2"
-  local revision="$3"
-  local cache_dir="$4"
-
-  if p6_string_blank "$revision" && p6_string_blank "$cache_dir"; then
-    python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id=\"$repo_id\", filename=\"$filename\")"
-  elif p6_string_blank "$cache_dir"; then
-    python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id=\"$repo_id\", filename=\"$filename\", revision=\"$revision\")"
-  else
-    python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id=\"$repo_id\", filename=\"$filename\", revision=\"$revision\", cache_dir=\"$cache_dir\")"
-  fi
-}
-
-######################################################################
-#<
-#
-# Function: p6_hf_repo_create(repo_id)
-#
-#  Args:
-#	repo_id -
-#
-#>
-######################################################################
-p6_hf_repo_create() {
-  local repo_id="$1"
-
-  python -c "from huggingface_hub import create_repo; create_repo(repo_id=\"$repo_id\")"
-}
-
-######################################################################
-#<
-#
-# Function: p6_hf_file_upload(path_or_fileobj, path_in_repo, repo_id)
-#
-#  Args:
-#	path_or_fileobj -
-#	path_in_repo -
-#	repo_id -
-#
-#>
-######################################################################
-p6_hf_file_upload() {
-  local path_or_fileobj="$1"
-  local path_in_repo="$2"
-  local repo_id="$3"
-
-  python -c "from huggingface_hub import upload_file; upload_file(path_or_fileobj=\"$path_or_fileobj\", path_in_repo=\"$path_in_repo\", repo_id=\"$repo_id\")"
-}
 
 ######################################################################
 #<


### PR DESCRIPTION
## Summary
- Remove `p6_hf_hub_download`, `p6_hf_repo_create`, `p6_hf_file_upload` from this df module
- Add `p6m7g8-dotfiles/p6huggingface` to `deps()` so the library is loaded
- Add `p6_return_void` to `external::brews()`
- Add `merge_group` CI trigger

## Test plan
- [ ] Verify `p6_hf_hub_download` is available after module load (via p6huggingface dep)