### PR TITLE
chore(huggingface): update aliases::init args and rename prompt::mod to profile::mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 
 ## Summary
 
-p6df module for Hugging Face: Python ML utilities (`transformers`, `huggingface-hub`),
-prompt integration, aliases, and MCP server (`hf-mcp-server` via brew) for
-AI-driven model discovery and dataset management.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -43,28 +41,17 @@ AI-driven model discovery and dataset management.
 
 ##### p6df-huggingface/init.zsh
 
-- `p6_hf_file_upload(path_or_fileobj, path_in_repo, repo_id)`
+- `p6df::modules::huggingface::aliases::init(_module, _dir)`
   - Args:
-    - path_or_fileobj
-    - path_in_repo
-    - repo_id
-- `p6_hf_hub_download(repo_id, filename, revision, cache_dir)`
-  - Args:
-    - repo_id
-    - filename
-    - revision
-    - cache_dir
-- `p6_hf_repo_create(repo_id)`
-  - Args:
-    - repo_id
-- `p6df::modules::huggingface::aliases::init()`
+    - _module
+    - _dir
 - `p6df::modules::huggingface::clones()`
 - `p6df::modules::huggingface::deps()`
 - `p6df::modules::huggingface::external::brews()`
 - `p6df::modules::huggingface::langs()`
 - `p6df::modules::huggingface::mcp()`
 - `p6df::modules::huggingface::vscodes()`
-- `str str = p6df::modules::huggingface::prompt::mod()`
+- `str str = p6df::modules::huggingface::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -16,7 +16,11 @@ p6df::modules::huggingface::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::huggingface::aliases::init()
+# Function: p6df::modules::huggingface::aliases::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #>
 ######################################################################


### PR DESCRIPTION
**What:** Add `_module` and `_dir` arg docs to `aliases::init` in `init.zsh`; rename `prompt::mod` to `profile::mod` in README; remove stale Python helper function docs and reset Summary placeholder.

**Why:** Aligns doc comments and README with actual function signatures and naming conventions used across the framework.

**Test plan:** Comment and README changes only; no functional logic changed.

**Dependencies:** none